### PR TITLE
Fixed file selection issue in android 11+

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -14,6 +14,7 @@
     <uses-permission android:name="android.permission.SEND_SMS" />
 
     <application
+            android:requestLegacyExternalStorage="true"
             android:allowBackup="true"
             android:name=".backend.MyCustomApplication"
             android:icon="@mipmap/ic_launcher"


### PR DESCRIPTION
There is an issue in file choose dialog due to android 11 storage update.
There are no files in the list. Only directories.
See https://stackoverflow.com/questions/63898697/why-file-listfiles-method-can-only-list-directories/71216457#71216457